### PR TITLE
PiOS: Place USB descriptors in RAM

### DIFF
--- a/flight/PiOS/Common/pios_usb_desc_hid_cdc.c
+++ b/flight/PiOS/Common/pios_usb_desc_hid_cdc.c
@@ -183,7 +183,7 @@ struct usb_config_hid_cdc {
 	struct usb_endpoint_desc              hid_out;
 } __attribute__((packed));
 
-static const struct usb_config_hid_cdc config_hid_cdc = {
+static struct usb_config_hid_cdc config_hid_cdc = {
 	.config = {
 		.bLength              = sizeof(struct usb_configuration_desc),
 		.bDescriptorType      = USB_DESC_TYPE_CONFIGURATION,

--- a/flight/PiOS/Common/pios_usb_desc_hid_only.c
+++ b/flight/PiOS/Common/pios_usb_desc_hid_only.c
@@ -103,7 +103,7 @@ struct usb_config_hid_only {
 	struct usb_endpoint_desc              hid_out;
 } __attribute__((packed));
 
-const struct usb_config_hid_only config_hid_only = {
+static struct usb_config_hid_only config_hid_only = {
 	.config = {
 		.bLength              = sizeof(struct usb_configuration_desc),
 		.bDescriptorType      = USB_DESC_TYPE_CONFIGURATION,


### PR DESCRIPTION
The new ST USB drivers were trying to write to them causing a flash fault. This took some hours to debug chasing it back through the USB stack eventually back to PiOS again. :-P
