### PR TITLE
Put the USB descriptors back in Flash

### DIFF
--- a/flight/PiOS/Common/pios_usb_desc_hid_cdc.c
+++ b/flight/PiOS/Common/pios_usb_desc_hid_cdc.c
@@ -183,7 +183,7 @@ struct usb_config_hid_cdc {
 	struct usb_endpoint_desc              hid_out;
 } __attribute__((packed));
 
-static struct usb_config_hid_cdc config_hid_cdc = {
+static const struct usb_config_hid_cdc config_hid_cdc = {
 	.config = {
 		.bLength              = sizeof(struct usb_configuration_desc),
 		.bDescriptorType      = USB_DESC_TYPE_CONFIGURATION,

--- a/flight/PiOS/Common/pios_usb_desc_hid_only.c
+++ b/flight/PiOS/Common/pios_usb_desc_hid_only.c
@@ -103,7 +103,7 @@ struct usb_config_hid_only {
 	struct usb_endpoint_desc              hid_out;
 } __attribute__((packed));
 
-static struct usb_config_hid_only config_hid_only = {
+const struct usb_config_hid_only config_hid_only = {
 	.config = {
 		.bLength              = sizeof(struct usb_configuration_desc),
 		.bDescriptorType      = USB_DESC_TYPE_CONFIGURATION,

--- a/flight/PiOS/STM32F10x/pios_usbhook.c
+++ b/flight/PiOS/STM32F10x/pios_usbhook.c
@@ -41,7 +41,7 @@
 
 static ONE_DESCRIPTOR Device_Descriptor;
 
-void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterDevice(const uint8_t * desc, uint16_t desc_size)
 {
 	Device_Descriptor.Descriptor      = desc;
 	Device_Descriptor.Descriptor_Size = desc_size;
@@ -49,7 +49,7 @@ void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t desc_size)
 
 static ONE_DESCRIPTOR Config_Descriptor;
 
-void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, const uint8_t * desc, uint16_t desc_size)
 {
 	Config_Descriptor.Descriptor      = desc;
 	Config_Descriptor.Descriptor_Size = desc_size;
@@ -57,7 +57,7 @@ void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, uint8_t * desc, uint16_t des
 
 static ONE_DESCRIPTOR String_Descriptor[4];
 
-void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, const uint8_t * desc, uint16_t desc_size)
 {
 	if (string_id < NELEMENTS(String_Descriptor)) {
 		String_Descriptor[string_id].Descriptor      = desc;
@@ -67,7 +67,7 @@ void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc,
 
 static ONE_DESCRIPTOR Hid_Descriptor;
 
-void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t desc_size)
+void PIOS_USB_HID_RegisterHidDescriptor(const uint8_t * desc, uint16_t desc_size)
 {
 	Hid_Descriptor.Descriptor      = desc;
 	Hid_Descriptor.Descriptor_Size = desc_size;
@@ -75,7 +75,7 @@ void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t desc_size)
 
 static ONE_DESCRIPTOR Hid_Report_Descriptor;
 
-void PIOS_USB_HID_RegisterHidReport(uint8_t * desc, uint16_t desc_size)
+void PIOS_USB_HID_RegisterHidReport(const uint8_t * desc, uint16_t desc_size)
 {
 	Hid_Report_Descriptor.Descriptor      = desc;
 	Hid_Report_Descriptor.Descriptor_Size = desc_size;

--- a/flight/PiOS/STM32F30x/pios_usbhook.c
+++ b/flight/PiOS/STM32F30x/pios_usbhook.c
@@ -42,7 +42,7 @@
 
 static ONE_DESCRIPTOR Device_Descriptor;
 
-void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterDevice(const uint8_t * desc, uint16_t desc_size)
 {
 	Device_Descriptor.Descriptor      = desc;
 	Device_Descriptor.Descriptor_Size = desc_size;
@@ -50,7 +50,7 @@ void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t desc_size)
 
 static ONE_DESCRIPTOR Config_Descriptor;
 
-void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, const uint8_t * desc, uint16_t desc_size)
 {
 	Config_Descriptor.Descriptor      = desc;
 	Config_Descriptor.Descriptor_Size = desc_size;
@@ -58,7 +58,7 @@ void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, uint8_t * desc, uint16_t des
 
 static ONE_DESCRIPTOR String_Descriptor[4];
 
-void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, const uint8_t * desc, uint16_t desc_size)
 {
 	if (string_id < NELEMENTS(String_Descriptor)) {
 		String_Descriptor[string_id].Descriptor      = desc;
@@ -68,7 +68,7 @@ void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc,
 
 static ONE_DESCRIPTOR Hid_Descriptor;
 
-void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t desc_size)
+void PIOS_USB_HID_RegisterHidDescriptor(const uint8_t * desc, uint16_t desc_size)
 {
 	Hid_Descriptor.Descriptor      = desc;
 	Hid_Descriptor.Descriptor_Size = desc_size;
@@ -76,7 +76,7 @@ void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t desc_size)
 
 static ONE_DESCRIPTOR Hid_Report_Descriptor;
 
-void PIOS_USB_HID_RegisterHidReport(uint8_t * desc, uint16_t desc_size)
+void PIOS_USB_HID_RegisterHidReport(const uint8_t * desc, uint16_t desc_size)
 {
 	Hid_Report_Descriptor.Descriptor      = desc;
 	Hid_Report_Descriptor.Descriptor_Size = desc_size;

--- a/flight/PiOS/STM32F4xx/Libraries/STM32_USB_Device_Library/Core/inc/usbd_ioreq.h
+++ b/flight/PiOS/STM32F4xx/Libraries/STM32_USB_Device_Library/Core/inc/usbd_ioreq.h
@@ -83,7 +83,7 @@
   */ 
 
 USBD_Status  USBD_CtlSendData (USB_OTG_CORE_HANDLE  *pdev, 
-                               uint8_t *buf,
+                               const uint8_t *buf,
                                uint16_t len);
 
 USBD_Status  USBD_CtlContinueSendData (USB_OTG_CORE_HANDLE  *pdev, 

--- a/flight/PiOS/STM32F4xx/Libraries/STM32_USB_Device_Library/Core/src/usbd_ioreq.c
+++ b/flight/PiOS/STM32F4xx/Libraries/STM32_USB_Device_Library/Core/src/usbd_ioreq.c
@@ -93,7 +93,7 @@
 * @retval status
 */
 USBD_Status  USBD_CtlSendData (USB_OTG_CORE_HANDLE  *pdev, 
-                               uint8_t *pbuf,
+                               const uint8_t *pbuf,
                                uint16_t len)
 {
   USBD_Status ret = USBD_OK;

--- a/flight/PiOS/STM32F4xx/Libraries/STM32_USB_Device_Library/Core/src/usbd_req.c
+++ b/flight/PiOS/STM32F4xx/Libraries/STM32_USB_Device_Library/Core/src/usbd_req.c
@@ -373,7 +373,7 @@ static void USBD_GetDescriptor(USB_OTG_CORE_HANDLE  *pdev,
                                USB_SETUP_REQ *req)
 {
   uint16_t len;
-  uint8_t *pbuf;
+  const uint8_t *pbuf;
   len = req->wLength ;
     
   switch (req->wValue >> 8)
@@ -396,7 +396,9 @@ static void USBD_GetDescriptor(USB_OTG_CORE_HANDLE  *pdev,
       pbuf   = (uint8_t *)pdev->dev.class_cb->GetOtherConfigDescriptor(pdev->cfg.speed, &len);
     }
 #endif  
-    pbuf[1] = USB_DESC_TYPE_CONFIGURATION;
+    // This line would mean the descriptors could not longer live in flash
+    // Removed as we always set the type to USB_DESC_TYPE_CONFIGURATION anyway
+    //pbuf[1] = USB_DESC_TYPE_CONFIGURATION;
     pdev->dev.pConfig_descriptor = pbuf;    
     break;
     

--- a/flight/PiOS/STM32F4xx/Libraries/STM32_USB_OTG_Driver/inc/usb_core.h
+++ b/flight/PiOS/STM32F4xx/Libraries/STM32_USB_OTG_Driver/inc/usb_core.h
@@ -188,16 +188,16 @@ typedef  struct  usb_setup_req {
 
 typedef struct _Device_TypeDef
 {
-  uint8_t  *(*GetDeviceDescriptor)( uint8_t speed , uint16_t *length);  
-  uint8_t  *(*GetLangIDStrDescriptor)( uint8_t speed , uint16_t *length); 
-  uint8_t  *(*GetManufacturerStrDescriptor)( uint8_t speed , uint16_t *length);  
-  uint8_t  *(*GetProductStrDescriptor)( uint8_t speed , uint16_t *length);  
-  uint8_t  *(*GetSerialStrDescriptor)( uint8_t speed , uint16_t *length);  
-  uint8_t  *(*GetConfigurationStrDescriptor)( uint8_t speed , uint16_t *length);  
-  uint8_t  *(*GetInterfaceStrDescriptor)( uint8_t speed , uint16_t *length); 
+  const uint8_t  *(*GetDeviceDescriptor)( uint8_t speed , uint16_t *length);  
+  const uint8_t  *(*GetLangIDStrDescriptor)( uint8_t speed , uint16_t *length); 
+  const uint8_t  *(*GetManufacturerStrDescriptor)( uint8_t speed , uint16_t *length);  
+  const uint8_t  *(*GetProductStrDescriptor)( uint8_t speed , uint16_t *length);  
+  const uint8_t  *(*GetSerialStrDescriptor)( uint8_t speed , uint16_t *length);  
+  const uint8_t  *(*GetConfigurationStrDescriptor)( uint8_t speed , uint16_t *length);  
+  const uint8_t  *(*GetInterfaceStrDescriptor)( uint8_t speed , uint16_t *length); 
 
 #if (USBD_LPM_ENABLED == 1)
-  uint8_t  *(*GetBOSDescriptor)( uint8_t speed , uint16_t *length); 
+  const uint8_t  *(*GetBOSDescriptor)( uint8_t speed , uint16_t *length); 
 #endif   
 } USBD_DEVICE, *pUSBD_DEVICE;
 
@@ -216,13 +216,13 @@ typedef struct _Device_cb
   uint8_t  (*IsoINIncomplete)  (void *pdev); 
   uint8_t  (*IsoOUTIncomplete)  (void *pdev);   
 
-  uint8_t  *(*GetConfigDescriptor)( uint8_t speed , uint16_t *length); 
+  const uint8_t  *(*GetConfigDescriptor)( uint8_t speed , uint16_t *length); 
 #ifdef USB_OTG_HS_CORE 
-  uint8_t  *(*GetOtherConfigDescriptor)( uint8_t speed , uint16_t *length);   
+  const uint8_t  *(*GetOtherConfigDescriptor)( uint8_t speed , uint16_t *length);   
 #endif
 
 #ifdef USB_SUPPORT_USER_STRING_DESC 
-  uint8_t  *(*GetUsrStrDescriptor)( uint8_t speed ,uint8_t index,  uint16_t *length);   
+  const uint8_t  *(*GetUsrStrDescriptor)( uint8_t speed ,uint8_t index,  uint16_t *length);   
 #endif  
   
 } USBD_Class_cb_TypeDef;
@@ -259,7 +259,7 @@ typedef struct _DCD
   USBD_Class_cb_TypeDef         *class_cb;
   USBD_Usr_cb_TypeDef           *usr_cb;
   USBD_DEVICE                   *usr_device;  
-  uint8_t        *pConfig_descriptor;
+  const uint8_t        *pConfig_descriptor;
  }
 DCD_DEV , *DCD_PDEV;
 

--- a/flight/PiOS/STM32F4xx/Libraries/STM32_USB_OTG_Driver/inc/usb_dcd.h
+++ b/flight/PiOS/STM32F4xx/Libraries/STM32_USB_OTG_Driver/inc/usb_dcd.h
@@ -128,7 +128,7 @@ uint32_t   DCD_EP_PrepareRx ( USB_OTG_CORE_HANDLE *pdev,
   
 uint32_t    DCD_EP_Tx (USB_OTG_CORE_HANDLE *pdev,
                                uint8_t  ep_addr,
-                               uint8_t  *pbuf,
+                               const uint8_t  *pbuf,
                                uint32_t   buf_len);
 uint32_t    DCD_EP_Stall (USB_OTG_CORE_HANDLE *pdev,
                               uint8_t   epnum);

--- a/flight/PiOS/STM32F4xx/Libraries/STM32_USB_OTG_Driver/src/usb_dcd.c
+++ b/flight/PiOS/STM32F4xx/Libraries/STM32_USB_OTG_Driver/src/usb_dcd.c
@@ -270,7 +270,7 @@ uint32_t   DCD_EP_PrepareRx( USB_OTG_CORE_HANDLE *pdev,
 */
 uint32_t  DCD_EP_Tx ( USB_OTG_CORE_HANDLE *pdev,
                      uint8_t   ep_addr,
-                     uint8_t   *pbuf,
+                     const uint8_t   *pbuf,
                      uint32_t   buf_len)
 {
   USB_OTG_EP *ep;
@@ -280,7 +280,7 @@ uint32_t  DCD_EP_Tx ( USB_OTG_CORE_HANDLE *pdev,
   /* Setup and start the Transfer */
   ep->is_in = 1;
   ep->num = ep_addr & 0x7F;  
-  ep->xfer_buff = pbuf;
+  ep->xfer_buff = (uint8_t*)pbuf;
   ep->dma_addr = (uint32_t)pbuf;  
   ep->xfer_count = 0;
   ep->xfer_len  = buf_len;

--- a/flight/PiOS/STM32F4xx/pios_usb_hid.c
+++ b/flight/PiOS/STM32F4xx/pios_usb_hid.c
@@ -152,7 +152,7 @@ out_fail:
 
 static struct pios_usbhook_descriptor hid_desc;
 
-void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t length)
+void PIOS_USB_HID_RegisterHidDescriptor(const uint8_t * desc, uint16_t length)
 {
 	hid_desc.descriptor = desc;
 	hid_desc.length     = length;
@@ -160,7 +160,7 @@ void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t length)
 
 static struct pios_usbhook_descriptor hid_report_desc;
 
-void PIOS_USB_HID_RegisterHidReport(uint8_t * desc, uint16_t length)
+void PIOS_USB_HID_RegisterHidReport(const uint8_t * desc, uint16_t length)
 {
 	hid_report_desc.descriptor = desc;
 	hid_report_desc.length     = length;

--- a/flight/PiOS/STM32F4xx/pios_usbhook.c
+++ b/flight/PiOS/STM32F4xx/pios_usbhook.c
@@ -49,7 +49,7 @@
  */
 static struct pios_usbhook_descriptor Device_Descriptor;
 
-void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t length)
+void PIOS_USBHOOK_RegisterDevice(const uint8_t * desc, uint16_t length)
 {
 	Device_Descriptor.descriptor = desc;
 	Device_Descriptor.length     = length;
@@ -57,7 +57,7 @@ void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t length)
 
 static struct pios_usbhook_descriptor String_Descriptor[4];
 
-void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, const uint8_t * desc, uint16_t desc_size)
 {
 	if (string_id < NELEMENTS(String_Descriptor)) {
 		String_Descriptor[string_id].descriptor = desc;
@@ -67,7 +67,7 @@ void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc,
 
 static struct pios_usbhook_descriptor Config_Descriptor;
 
-void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, uint8_t * desc, uint16_t desc_size)
+void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, const uint8_t * desc, uint16_t desc_size)
 {
 	Config_Descriptor.descriptor = desc;
 	Config_Descriptor.length     = desc_size;
@@ -199,7 +199,7 @@ extern void PIOS_USBHOOK_DeRegisterEpOutCallback(uint8_t epnum)
 	DCD_EP_Close(&pios_usb_otg_core_handle, epnum);
 }
 
-void PIOS_USBHOOK_CtrlTx(uint8_t *buf, uint16_t len)
+void PIOS_USBHOOK_CtrlTx(const uint8_t *buf, uint16_t len)
 {
 	USBD_CtlSendData(&pios_usb_otg_core_handle, buf, len);
 }
@@ -209,7 +209,7 @@ void PIOS_USBHOOK_CtrlRx(uint8_t *buf, uint16_t len)
 	USBD_CtlPrepareRx(&pios_usb_otg_core_handle, buf, len);
 }
 
-void PIOS_USBHOOK_EndpointTx(uint8_t epnum, uint8_t *buf, uint16_t len)
+void PIOS_USBHOOK_EndpointTx(uint8_t epnum, const uint8_t *buf, uint16_t len)
 {
 	if (pios_usb_otg_core_handle.dev.device_status == USB_OTG_CONFIGURED) {
 		DCD_EP_Tx(&pios_usb_otg_core_handle, epnum, buf, len);
@@ -225,42 +225,42 @@ void PIOS_USBHOOK_EndpointRx(uint8_t epnum, uint8_t *buf, uint16_t len)
  * Device level hooks into STM USB library
  */
 
-static uint8_t * PIOS_USBHOOK_DEV_GetDeviceDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetDeviceDescriptor(uint8_t speed, uint16_t *length)
 {
 	*length = Device_Descriptor.length;
 	return Device_Descriptor.descriptor;
 }
 
-static uint8_t * PIOS_USBHOOK_DEV_GetLangIDStrDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetLangIDStrDescriptor(uint8_t speed, uint16_t *length)
 {
 	*length = String_Descriptor[USB_STRING_DESC_LANG].length;
 	return String_Descriptor[USB_STRING_DESC_LANG].descriptor;
 }
 
-static uint8_t * PIOS_USBHOOK_DEV_GetManufacturerStrDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetManufacturerStrDescriptor(uint8_t speed, uint16_t *length)
 {
 	*length = String_Descriptor[USB_STRING_DESC_VENDOR].length;
 	return String_Descriptor[USB_STRING_DESC_VENDOR].descriptor;
 }
 
-static uint8_t * PIOS_USBHOOK_DEV_GetProductStrDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetProductStrDescriptor(uint8_t speed, uint16_t *length)
 {
 	*length = String_Descriptor[USB_STRING_DESC_PRODUCT].length;
 	return String_Descriptor[USB_STRING_DESC_PRODUCT].descriptor;
 }
 
-static uint8_t * PIOS_USBHOOK_DEV_GetSerialStrDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetSerialStrDescriptor(uint8_t speed, uint16_t *length)
 {
 	*length = String_Descriptor[USB_STRING_DESC_SERIAL].length;
 	return String_Descriptor[USB_STRING_DESC_SERIAL].descriptor;
 }
 
-static uint8_t * PIOS_USBHOOK_DEV_GetConfigurationStrDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetConfigurationStrDescriptor(uint8_t speed, uint16_t *length)
 {
 	return NULL;
 }
 
-static uint8_t * PIOS_USBHOOK_DEV_GetInterfaceStrDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_DEV_GetInterfaceStrDescriptor(uint8_t speed, uint16_t *length)
 {
 	return NULL;
 }
@@ -450,7 +450,7 @@ static uint8_t PIOS_USBHOOK_CLASS_IsoOUTIncomplete(void *pdev)
 	return USBD_OK;
 }
 
-static uint8_t * PIOS_USBHOOK_CLASS_GetConfigDescriptor(uint8_t speed, uint16_t *length)
+static const uint8_t * PIOS_USBHOOK_CLASS_GetConfigDescriptor(uint8_t speed, uint16_t *length)
 {
 	*length = Config_Descriptor.length;
 	return Config_Descriptor.descriptor;

--- a/flight/PiOS/inc/pios_usb_hid.h
+++ b/flight/PiOS/inc/pios_usb_hid.h
@@ -35,8 +35,8 @@ extern int32_t PIOS_USB_HID_Reenumerate(void);
 extern int32_t PIOS_USB_HID_ChangeConnectionState(uint32_t Connected);
 extern bool PIOS_USB_HID_CheckAvailable(uint8_t id);
 
-extern void PIOS_USB_HID_RegisterHidDescriptor(uint8_t * desc, uint16_t length);
-extern void PIOS_USB_HID_RegisterHidReport(uint8_t * desc, uint16_t length);
+extern void PIOS_USB_HID_RegisterHidDescriptor(const uint8_t * desc, uint16_t length);
+extern void PIOS_USB_HID_RegisterHidReport(const uint8_t * desc, uint16_t length);
 
 #endif /* PIOS_USB_HID_H */
 

--- a/flight/PiOS/inc/pios_usbhook.h
+++ b/flight/PiOS/inc/pios_usbhook.h
@@ -37,7 +37,7 @@
 #include "pios_usb_defs.h"	/* usb_setup_request */
 
 struct pios_usbhook_descriptor {
-	uint8_t * descriptor;
+	const uint8_t * descriptor;
 	uint16_t length;
 };
 
@@ -48,9 +48,9 @@ enum usb_string_desc {
 	USB_STRING_DESC_SERIAL  = 3,
 } __attribute__((packed));
 
-extern void PIOS_USBHOOK_RegisterDevice(uint8_t * desc, uint16_t desc_size);
-extern void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, uint8_t * desc, uint16_t desc_size);
-extern void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, uint8_t * desc, uint16_t desc_size);
+extern void PIOS_USBHOOK_RegisterDevice(const uint8_t * desc, uint16_t desc_size);
+extern void PIOS_USBHOOK_RegisterConfig(uint8_t config_id, const uint8_t * desc, uint16_t desc_size);
+extern void PIOS_USBHOOK_RegisterString(enum usb_string_desc string_id, const uint8_t * desc, uint16_t desc_size);
 
 struct pios_usb_ifops {
   void (*init)(uintptr_t context);
@@ -68,9 +68,9 @@ extern void PIOS_USBHOOK_RegisterEpOutCallback(uint8_t epnum, uint16_t max_len, 
 extern void PIOS_USBHOOK_DeRegisterEpInCallback(uint8_t epnum);
 extern void PIOS_USBHOOK_DeRegisterEpOutCallback(uint8_t epnum);
 
-extern void PIOS_USBHOOK_CtrlTx(uint8_t *buf, uint16_t len);
+extern void PIOS_USBHOOK_CtrlTx(const uint8_t *buf, uint16_t len);
 extern void PIOS_USBHOOK_CtrlRx(uint8_t *buf, uint16_t len);
-extern void PIOS_USBHOOK_EndpointTx(uint8_t epnum, uint8_t *buf, uint16_t len);
+extern void PIOS_USBHOOK_EndpointTx(uint8_t epnum, const uint8_t *buf, uint16_t len);
 extern void PIOS_USBHOOK_EndpointRx(uint8_t epnum, uint8_t *buf, uint16_t len);
 extern void PIOS_USBHOOK_Activate(void);
 extern void PIOS_USBHOOK_Deactivate(void);


### PR DESCRIPTION
I removed the offending line of code that attempted to write the descriptor, reverted your commits that removed the const qualifiers and reverted all of ST's removal of const qualifiers. Tested okay to flash and run firmware.
